### PR TITLE
Changes MIME-type to `application/rss+xml`

### DIFF
--- a/lib/gateway.py
+++ b/lib/gateway.py
@@ -276,7 +276,7 @@ class _RequestHandler(http.server.SimpleHTTPRequestHandler):
 			# Add a newline at the end for saner debugging with curl.
 			data = (str(doc) + '\n').encode()
 			
-			self._send_headers(200, { 'content-type': 'application/atom+xml; charset=utf-8' })
+			self._send_headers(200, { 'content-type': 'application/rss+xml; charset=utf-8' })
 			
 			self.wfile.write(data)
 	


### PR DESCRIPTION
Changes HTTP `content-type` from `application/atom+xml` to `application/rss+xml`. Fixes #17 but might (but really should not) break compatibility with other clients than PocketCasts.